### PR TITLE
feat: 프로필 관심 키워드 선택 페이지 UI 퍼블리싱

### DIFF
--- a/lib/screen/register.dart
+++ b/lib/screen/register.dart
@@ -116,13 +116,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                     //         }
                     //       }
                     //     : null,
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => ProfileInfoScreen(),
-                        ),
-                      );
+                    onTap: () {;
                     },
                     child: Container(
                       width: 329,

--- a/lib/screen/register.dart
+++ b/lib/screen/register.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:project_aa/screen/profile_setting/profile_info.dart';
+import 'package:project_aa/screen/profile_setting/profile_keyword.dart';
 import 'package:project_aa/utils/utils.dart';
 
 class RegisterScreen extends StatefulWidget {
@@ -116,7 +117,13 @@ class _RegisterScreenState extends State<RegisterScreen> {
                     //         }
                     //       }
                     //     : null,
-                    onTap: () {;
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => ProfileKeywordScreen(),
+                        ),
+                      );
                     },
                     child: Container(
                       width: 329,


### PR DESCRIPTION
## 📌 작업 개요
프로필 등록 3단계인 관심 키워드 선택 페이지 UI 퍼블리싱을 진행했습니다.

---

## 🧩 작업 내용
- 관심 키워드 리스트 UI 구성
- Chip 형태의 키워드 선택 UI 구현
- 다중 선택 가능하도록 처리
- 최소 선택 개수 기준에 따른 완료 버튼 활성화
- 최대 선택 개수 제한

---

## 🏗️ 구현 범위
- UI 퍼블리싱만 포함
- 키워드 저장 및 API 연동은 포함하지 않음
- 선택 상태는 Controller에서 관리하도록 구조 설계

---

## 🔗 관련 이슈
- closes #12 
